### PR TITLE
Button 컴포넌트 + ModalDialog 컴포넌트 구현

### DIFF
--- a/app/globalStyles.ts
+++ b/app/globalStyles.ts
@@ -58,7 +58,8 @@ export const GlobalStyles = createGlobalStyle`
       box-sizing:inherit
   }
   button, input, select{
-    margin:0
+    margin:0;
+    border:0;
   }
 
   // global variables
@@ -69,5 +70,6 @@ export const GlobalStyles = createGlobalStyle`
   --safety: #4dcfca;
   --disabled: #d9d9d9;
   --white: #ffffff;
+  --black: #000000;
   }
 `;

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 const StyledButton = styled.button<ButtonProps>`
   width: 100%;
   min-width: 6.8125rem;
-  border-radius: ${({ type }) => (type === 'long' ? '0.9375rem' : '0.625rem')};
+  border-radius: ${({ isLong }) => (isLong ? '0.9375rem' : '0.625rem')};
   background-color: ${({ color }) => {
     switch (color) {
       case 'main':
@@ -19,14 +19,14 @@ const StyledButton = styled.button<ButtonProps>`
         return 'var(--disabled)';
     }
   }};
-  padding: ${({ type }) => (type === 'long' ? '0.5rem' : '0.625rem')};
+  padding: ${({ isLong }) => (isLong ? '0.5rem' : '0.625rem')};
   font-size: 1rem;
   font-weight: 700;
   color: ${({ color }) =>
     color === 'white' ? 'var(--black)' : 'var(--white)'};
   line-height: 1.25rem;
-  box-shadow: ${({ type }) =>
-    type === 'long' ? '0px 4px 4px 0px rgba(0, 0, 0, 0.25)' : ''};
+  box-shadow: ${({ isLong }) =>
+    isLong ? '0px 4px 4px 0px rgba(0, 0, 0, 0.25)' : ''};
   cursor: ${({ color }) => (color === 'disabled' ? 'not-allowed' : 'pointer')};
   border: ${({ color }) =>
     `0.0625rem solid ${color === 'white' ? 'var(--disabled)' : 'transparent'}`};
@@ -35,18 +35,18 @@ const StyledButton = styled.button<ButtonProps>`
 /* ---------------------------------- type ---------------------------------- */
 type ButtonProps = {
   children?: string;
-  type: 'long' | 'short';
+  isLong: boolean;
   color: 'main' | 'sub' | 'white' | 'disabled';
   onClick?: () => void;
 };
 
 /* -------------------------------- component ------------------------------- */
-const Button = ({ children, type, color, onClick }: ButtonProps) => {
+const Button = ({ children, isLong, color, onClick }: ButtonProps) => {
   const isDisabled = color === 'disabled';
 
   return (
     <StyledButton
-      type={type}
+      isLong={isLong}
       color={color}
       disabled={isDisabled}
       onClick={onClick}

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -21,7 +21,7 @@ const StyledButton = styled.button<ButtonProps>`
   }};
   padding: ${({ isLong }) => (isLong ? '0.5rem' : '0.625rem')};
   font-size: 1rem;
-  font-weight: 700;
+  font-weight: bold;
   color: ${({ color }) =>
     color === 'white' ? 'var(--black)' : 'var(--white)'};
   line-height: 1.25rem;

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import styled from 'styled-components';
+
+/* ---------------------------------- style --------------------------------- */
+const StyledButton = styled.button<ButtonProps>`
+  width: 100%;
+  min-width: 6.8125rem;
+  border-radius: ${({ type }) => (type === 'long' ? '0.9375rem' : '0.625rem')};
+  background-color: ${({ color }) => {
+    switch (color) {
+      case 'main':
+        return 'var(--main)';
+      case 'sub':
+        return 'var(--sub)';
+      case 'white':
+        return 'var(--white)';
+      case 'disabled':
+        return 'var(--disabled)';
+    }
+  }};
+  padding: ${({ type }) => (type === 'long' ? '0.5rem' : '0.625rem')};
+  font-size: 1rem;
+  font-weight: 700;
+  color: ${({ color }) =>
+    color === 'white' ? 'var(--black)' : 'var(--white)'};
+  line-height: 1.25rem;
+  box-shadow: ${({ type }) =>
+    type === 'long' ? '0px 4px 4px 0px rgba(0, 0, 0, 0.25)' : ''};
+  cursor: ${({ color }) => (color === 'disabled' ? 'not-allowed' : 'pointer')};
+  border: ${({ color }) =>
+    `0.0625rem solid ${color === 'white' ? 'var(--disabled)' : 'transparent'}`};
+`;
+
+/* ---------------------------------- type ---------------------------------- */
+type ButtonProps = {
+  children?: string;
+  type: 'long' | 'short';
+  color: 'main' | 'sub' | 'white' | 'disabled';
+  onClick?: () => void;
+};
+
+/* -------------------------------- component ------------------------------- */
+const Button = ({ children, type, color, onClick }: ButtonProps) => {
+  const isDisabled = color === 'disabled';
+
+  return (
+    <StyledButton
+      type={type}
+      color={color}
+      disabled={isDisabled}
+      onClick={onClick}
+    >
+      {children}
+    </StyledButton>
+  );
+};
+
+export default Button;

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -2,13 +2,15 @@
 
 import styled from 'styled-components';
 
+type ButtonColor = 'main' | 'sub' | 'white' | 'disabled';
+
 /* ---------------------------------- style --------------------------------- */
-const StyledButton = styled.button<ButtonProps>`
+const StyledButton = styled.button<{ $isLong: boolean; $color: ButtonColor }>`
   width: 100%;
   min-width: 6.8125rem;
-  border-radius: ${({ isLong }) => (isLong ? '0.9375rem' : '0.625rem')};
-  background-color: ${({ color }) => {
-    switch (color) {
+  border-radius: ${({ $isLong }) => ($isLong ? '0.9375rem' : '0.625rem')};
+  background-color: ${({ $color }) => {
+    switch ($color) {
       case 'main':
         return 'var(--main)';
       case 'sub':
@@ -19,24 +21,26 @@ const StyledButton = styled.button<ButtonProps>`
         return 'var(--disabled)';
     }
   }};
-  padding: ${({ isLong }) => (isLong ? '0.5rem' : '0.625rem')};
+  padding: ${({ $isLong }) => ($isLong ? '0.5rem' : '0.625rem')};
   font-size: 1rem;
   font-weight: bold;
-  color: ${({ color }) =>
-    color === 'white' ? 'var(--black)' : 'var(--white)'};
+  color: ${({ $color }) =>
+    $color === 'white' ? 'var(--black)' : 'var(--white)'};
   line-height: 1.25rem;
-  box-shadow: ${({ isLong }) =>
-    isLong ? '0px 4px 4px 0px rgba(0, 0, 0, 0.25)' : ''};
-  cursor: ${({ color }) => (color === 'disabled' ? 'not-allowed' : 'pointer')};
-  border: ${({ color }) =>
-    `0.0625rem solid ${color === 'white' ? 'var(--disabled)' : 'transparent'}`};
+  box-shadow: ${({ $isLong }) =>
+    $isLong ? '0px 4px 4px 0px rgba(0, 0, 0, 0.25)' : ''};
+  cursor: ${({ $color }) =>
+    $color === 'disabled' ? 'not-allowed' : 'pointer'};
+  border: ${({ $color }) =>
+    `0.0625rem solid ${$color === 'white' ? 'var(--disabled)' : 'transparent'}`};
 `;
 
 /* ---------------------------------- type ---------------------------------- */
+
 type ButtonProps = {
   children?: string;
   isLong: boolean;
-  color: 'main' | 'sub' | 'white' | 'disabled';
+  color: ButtonColor;
   onClick?: () => void;
 };
 
@@ -46,8 +50,8 @@ const Button = ({ children, isLong, color, onClick }: ButtonProps) => {
 
   return (
     <StyledButton
-      isLong={isLong}
-      color={color}
+      $isLong={isLong}
+      $color={color}
       disabled={isDisabled}
       onClick={onClick}
     >

--- a/components/ModalDialog.tsx
+++ b/components/ModalDialog.tsx
@@ -13,6 +13,7 @@ const OverLayBox = styled.div`
   left: 0;
   width: 100%;
   height: 100vh;
+  z-index: 9999;
 `;
 const DialogBox = styled.div`
   background-color: var(--white);

--- a/components/ModalDialog.tsx
+++ b/components/ModalDialog.tsx
@@ -30,17 +30,17 @@ const ButtonWrapper = styled.div`
 
 /* -------------------------------- type ------------------------------- */
 type ModalDialogProps = {
-  children: ReactNode;
-  type: 'one-button' | 'two-button';
+  children?: ReactNode;
+  buttonCount: 0 | 1 | 2;
   isOpen: boolean;
   onConfirm?: () => void;
-  onClose: () => void;
+  onClose?: () => void;
 };
 
 /* -------------------------------- component ------------------------------- */
 const ModalDialog = ({
   children,
-  type,
+  buttonCount,
   isOpen,
   onConfirm,
   onClose,
@@ -48,27 +48,30 @@ const ModalDialog = ({
   useBodyScrollLock(isOpen);
 
   const handleOverLayClick = (e: MouseEvent) => {
-    if (e.target === e.currentTarget) onClose();
+    if (e.target === e.currentTarget) onClose?.();
   };
 
   const renderButtons = () => {
-    if (type === 'one-button') {
-      return (
-        <Button type="short" color="main" onClick={onClose}>
-          예
-        </Button>
-      );
-    } else if (type === 'two-button') {
-      return (
-        <ButtonWrapper>
-          <Button type="short" color="main" onClick={onConfirm}>
+    switch (buttonCount) {
+      case 0:
+        return <></>;
+      case 1:
+        return (
+          <Button isLong={false} color="main" onClick={onClose}>
             예
           </Button>
-          <Button type="short" color="white" onClick={onClose}>
-            아니오
-          </Button>
-        </ButtonWrapper>
-      );
+        );
+      case 2:
+        return (
+          <ButtonWrapper>
+            <Button isLong={false} color="main" onClick={onConfirm}>
+              예
+            </Button>
+            <Button isLong={false} color="white" onClick={onClose}>
+              아니오
+            </Button>
+          </ButtonWrapper>
+        );
     }
   };
 

--- a/components/ModalDialog.tsx
+++ b/components/ModalDialog.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import useBodyScrollLock from '@/hooks/useBodyScrollLock';
+import { MouseEvent, ReactNode } from 'react';
+import styled from 'styled-components';
+import Button from './Button';
+
+/* ------------------------------- style ------------------------------ */
+const OverLayBox = styled.div`
+  background-color: rgba(0, 0, 0, 0.4);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+`;
+const DialogBox = styled.div`
+  background-color: var(--white);
+  position: absolute;
+  left: 50%;
+  top: 50vh;
+  translate: -50% -50%;
+  padding: 1.4375rem 1.6875rem;
+  border-radius: 0.9375rem;
+`;
+const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 1.75rem;
+`;
+
+/* -------------------------------- type ------------------------------- */
+type ModalDialogProps = {
+  children: ReactNode;
+  type: 'one-button' | 'two-button';
+  isOpen: boolean;
+  onConfirm?: () => void;
+  onClose: () => void;
+};
+
+/* -------------------------------- component ------------------------------- */
+const ModalDialog = ({
+  children,
+  type,
+  isOpen,
+  onConfirm,
+  onClose,
+}: ModalDialogProps) => {
+  useBodyScrollLock(isOpen);
+
+  const handleOverLayClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const renderButtons = () => {
+    if (type === 'one-button') {
+      return (
+        <Button type="short" color="main" onClick={onClose}>
+          예
+        </Button>
+      );
+    } else if (type === 'two-button') {
+      return (
+        <ButtonWrapper>
+          <Button type="short" color="main" onClick={onConfirm}>
+            예
+          </Button>
+          <Button type="short" color="white" onClick={onClose}>
+            아니오
+          </Button>
+        </ButtonWrapper>
+      );
+    }
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <OverLayBox onClick={handleOverLayClick}>
+          <DialogBox role="dialog" aria-modal="true" tabIndex={-1}>
+            {children}
+            {renderButtons()}
+          </DialogBox>
+        </OverLayBox>
+      )}
+    </>
+  );
+};
+
+export default ModalDialog;

--- a/hooks/useBodyScrollLock.ts
+++ b/hooks/useBodyScrollLock.ts
@@ -1,0 +1,28 @@
+import { useCallback, useLayoutEffect } from 'react';
+
+export default function useBodyScrollLock(isOpen: boolean) {
+  const lockScroll = useCallback(() => {
+    document.body.style.cssText = `
+    position:fixed;
+    top: -${window.scrollY}px;
+    left: 50%;
+    translate: -50%;
+    overflow-y: scroll;
+    width: 100%;
+    `;
+  }, []);
+
+  const openScroll = useCallback(() => {
+    const scrollY = document.body.style.top;
+    document.body.style.cssText = '';
+    window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (isOpen) lockScroll();
+
+    return () => {
+      openScroll();
+    };
+  }, [isOpen, lockScroll, openScroll]);
+}


### PR DESCRIPTION
## PR 유형

- [x] Feat: 새로운 기능 추가
- [ ] BugFix: 버그 수정
- [x] Design: CSS 등 사용자 UI 디자인 변경
- [ ] Style: 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] Refactor: 코드 리팩토링
- [ ] Comment: 주석 추가 및 수정
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가, 테스트 리팩토링
- [ ] Chore: 빌드 부분 혹은 패키지 매니저 수정
- [ ] Rename: 파일 혹은 폴더명 수정
- [ ] Remove: 파일 혹은 폴더 삭제

## 🔧 반영 브랜치

<!-- ex) feature/login -> develop -->
feature/ModalDialog -> develop

## 💬 Description

<!-- 리뷰하는 사람이 봐야할 내용을 작성해주세요. -->
<!-- 구현 한 기능에 대해 작성해 주세요. -->
- Button 컴포넌트는 사용성을 고려해서 width 100%로 했습니다. (Button 사용할 때, wrapper나 container크기를 맞춰서 사용)
- ModalDialog 컴포넌트의 버튼 위쪽 컨텐츠는 임의로 넣었습니다. (컨텐츠 style은 컴포넌트 사용할 때 설정해서 사용)
- useBodyScrollLock 훅은 모달 창이 열린 상태에서는 바깥쪽 스크롤이 되지 않도록 방지하는 기능입니다.

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
<!-- 스크린샷은 선택사항입니다. -->

<img width="200" alt="스크린샷 2025-01-23 오후 12 22 14" src="https://github.com/user-attachments/assets/117ab86c-904b-4104-a60f-5d76e3f56044" />

<img width="200" alt="스크린샷 2025-01-23 오후 12 22 34" src="https://github.com/user-attachments/assets/bddf6783-7e75-43e9-9bf7-8ac10fe39d49" />

<img width="200" alt="스크린샷 2025-01-23 오후 12 23 01" src="https://github.com/user-attachments/assets/99599144-1547-4277-940f-65e5591a3556" />

<!--
맨 마지막 줄에 아래 이슈
Fixes: 이슈 수정중 (아직 해결되지 않은 경우)
Resolves: 이슈를 해결했을 때 사용
Ref: 참고할 이슈가 있을 때 사용
Related to: 해당 커밋에 관련된 이슈번호 (아직 해결되지 않은 경우)

-여러 이슈를 입력시 comma(,) 단위로 구분해주세요
ex) Close #10, Resolves #123 -->
Resolves #4 